### PR TITLE
Use Bencher file option

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -29,4 +29,5 @@ jobs:
           --testbed ubuntu-latest \
           --adapter shell_hyperfine \
           --err \
+          --file results.json \
           "hyperfine --runs 2 --export-json results.json './src/bitcoind --stopatheight=5000'"

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,32 @@
+on:
+  push:
+    branches: master
+
+jobs:
+  benchmark_base_branch:
+    name: Bencher
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: bencherdev/bencher@main
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install hyperfine clang-15 ccache build-essential libtool autotools-dev automake pkg-config bsdmainutils python3-zmq libevent-dev libboost-dev libsqlite3-dev libdb++-dev systemtap-sdt-dev libminiupnpc-dev libnatpmp-dev libqt5gui5 libqt5core5a libqt5dbus5 qttools5-dev qttools5-dev-tools qtwayland5 libqrencode-dev -y
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          create-symlink: true
+      - name: Build bitcoind
+        run: |
+          ./autogen.sh && CC=clang-15 CXX=clang++-15 ./configure --disable-tests --disable-wallet --without-gui --disable-bench --disable-fuzz-binary && make clean && make -j $(nproc) -C src bitcoind
+      - name: Track base branch benchmarks with Bencher
+        run: |
+          bencher run \
+          --project core-test \
+          --token '${{ secrets.BENCHER_API_TOKEN }}' \
+          --branch master \
+          --testbed ubuntu-latest \
+          --adapter shell_hyperfine \
+          --err \
+          "hyperfine --runs 2 --export-json results.json './src/bitcoind --stopatheight=5000'"


### PR DESCRIPTION
Since we were having issues with email, I wanted to make sure you saw my response to this:

> The Shell Hyperfine Adapter (`shell_hyperfine`) expects [Hyperfine](https://github.com/sharkdp/hyperfine) output in [JSON format (ie `--export-json results.json`)](https://github.com/sharkdp/hyperfine/tree/master/scripts#example).
This JSON output is saved to a file, so you must use the `bencher run` CLI `--file` argument to specify that file path (ie `bencher run --file results.json "hyperfine --export-json results.json 'sleep 0.1'"`).

https://bencher.dev/docs/explanation/adapters/#_%EF%B8%8F-shell-hyperfine